### PR TITLE
Fix black bar at bottom of game screen with non-clearing frames

### DIFF
--- a/Assets/Main Camera.prefab
+++ b/Assets/Main Camera.prefab
@@ -26,13 +26,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4352894412594784951}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.8, y: 12.83, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &4352894412594784949
 Camera:
@@ -48,13 +48,21 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
-    y: 0.1
+    y: 0
     width: 1
     height: 1
   near clip plane: 0.3

--- a/Assets/Scripts/CameraManager.cs
+++ b/Assets/Scripts/CameraManager.cs
@@ -9,12 +9,13 @@ public class CameraManager : MonoBehaviour
     public Transform PlayerTransform;
 
     public Vector3 MinPos;
+    public Vector3 CameraOffset = new Vector3(0,-5,0);
     // Start is called before the first frame update
     void Start()
     {
         PlayerTransform = GameObject.FindGameObjectWithTag("Player").transform;
 
-        MinPos = this.gameObject.transform.position;
+        MinPos = gameObject.transform.position + CameraOffset;
         
     }
 
@@ -26,13 +27,11 @@ public class CameraManager : MonoBehaviour
 
     void FixedUpdate(){
         if(PlayerTransform.position.y < MinPos.y){
-            this.gameObject.transform.position = MinPos;
-
+            gameObject.transform.position = MinPos;
         }
         else{
-            Vector3 NewPos;
-            NewPos = new Vector3(this.transform.position.x, PlayerTransform.position.y, this.transform.position.z);
-            this.transform.position = NewPos;
+            Vector3 NewPos = new Vector3(transform.position.x, PlayerTransform.position.y, transform.position.z);
+            transform.position = NewPos;
         }
     }
 }

--- a/Assets/TestScene.unity
+++ b/Assets/TestScene.unity
@@ -4068,6 +4068,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4352894412594784947, guid: 000595dd0c88d4472a0ec8de46481c94, type: 3}
+      propertyPath: CameraOffset.y
+      value: -5
+      objectReference: {fileID: 0}
     - target: {fileID: 4352894412594784948, guid: 000595dd0c88d4472a0ec8de46481c94, type: 3}
       propertyPath: m_RootOrder
       value: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.6",
+    "com.unity.toolchain.linux-x86_64": "2.0.9",
     "com.unity.toolchain.macos-arm64-linux-x86_64": "2.0.3",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -113,6 +113,16 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.toolchain.linux-x86_64": {
+      "version": "2.0.9",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10",
+        "com.unity.sysroot.linux-x86_64": "2.0.9"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.toolchain.macos-arm64-linux-x86_64": {
       "version": "2.0.3",
       "depth": 0,


### PR DESCRIPTION
Fixes #1 

Changed MainCamera's viewport rect Y calue from 0.1 to 0.
While it was 0.1, the camera size did not conform with the game
size, causing a bar at the bottom of the screen which which did
not clear on each frame, causing previous drawn frames to remain
on screen layering on top of each other.

Changing the viewport rect does slightly push the camera higher up,
so an offset to the camera's minimum position has been added, so it is not
drawn on top of the character.

Screenshot of display without the black bar:
![fixed camera](https://github.com/user-attachments/assets/22cfffdb-ce3b-4d60-bc59-633fdc94511f)